### PR TITLE
Update to ratpack 0.9.17

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     jcenter()
   }
   dependencies {
-    classpath 'io.ratpack:ratpack-gradle:0.9.15'
+    classpath 'io.ratpack:ratpack-gradle:0.9.17'
     classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.1'
   }
 }

--- a/hopscotch-web/build.gradle
+++ b/hopscotch-web/build.gradle
@@ -10,7 +10,6 @@ dependencies {
     // springloaded "org.springframework:springloaded:1.2.1.RELEASE"
 
     compile ratpack.dependency("guice")
-    compile ratpack.dependency("config")
     compile ratpack.dependency("remote")
     compile ratpack.dependency("codahale-metrics")
     compile ratpack.dependency("rx")

--- a/hopscotch-web/src/main/java/charliek/hopscotch/web/ApiHandlerDecorator.java
+++ b/hopscotch-web/src/main/java/charliek/hopscotch/web/ApiHandlerDecorator.java
@@ -11,6 +11,7 @@ public class ApiHandlerDecorator implements HandlerDecorator {
 	public Handler decorate(Registry serverRegistry, Handler rest) throws Exception {
 		return Handlers.chain(rest, Handlers.chain(serverRegistry, c -> {
 			c.get("api/timed", TimedHandler.class);
+			// Add other api endpoints here
 		}));
 	}
 }

--- a/hopscotch-web/src/main/java/charliek/hopscotch/web/HopscotchApp.java
+++ b/hopscotch-web/src/main/java/charliek/hopscotch/web/HopscotchApp.java
@@ -18,7 +18,7 @@ public class HopscotchApp {
 			d.sysProps();
 		});
 
-		ServerConfig.Builder serverConfig = ServerConfig.findBaseDirProps().sysProps().env();
+		ServerConfig.Builder serverConfig = ServerConfig.findBaseDir().sysProps().env();
 
 		RatpackServer.start(spec -> {
 			spec.serverConfig(serverConfig);

--- a/hopscotch-web/src/main/java/charliek/hopscotch/web/HopscotchModule.java
+++ b/hopscotch-web/src/main/java/charliek/hopscotch/web/HopscotchModule.java
@@ -13,5 +13,8 @@ public class HopscotchModule extends AbstractModule {
 
 		bind(TimedHandler.class).in(Scopes.SINGLETON);
 		bind(ApiHandlerDecorator.class).in(Scopes.SINGLETON);
+
+		// Adding doesn't change the behavior anything
+		// Multibinder.newSetBinder(binder(), HandlerDecorator.class).addBinding().to(ApiHandlerDecorator.class);
 	}
 }


### PR DESCRIPTION
Update to ratpack 0.9.17.  Still not seeing the routes registered in the HopscotchModule -> ApiHandlerDecorator being registered as they were before.
